### PR TITLE
Add support for german azure cloud

### DIFF
--- a/lib/paperclip-azure.rb
+++ b/lib/paperclip-azure.rb
@@ -8,7 +8,7 @@ module Azure
     BlobService.class_eval do
       def initialize(signer=Core::Auth::SharedKey.new, account_name=Azure.config.storage_account_name)
         super(signer, account_name)
-        @host = "http://#{account_name}.blob.core.windows.net"
+        @host = Paperclip::Storage::AzureRegion.url_for account_name
       end
     end
   end

--- a/lib/paperclip/storage/azure_region.rb
+++ b/lib/paperclip/storage/azure_region.rb
@@ -1,0 +1,26 @@
+module Paperclip
+  module Storage
+    class AzureRegion
+
+      REGION_URL_POSTFIX = {
+        global: "blob.core.windows.net",
+        de: "blob.core.cloudapi.de"
+      }
+
+      def self.url_for(account_name)
+        "http://#{account_name}.#{postfix}"
+      end
+
+    private
+
+      def self.postfix
+        region = credentials[:region] || :global
+        REGION_URL_POSTFIX[region.to_sym]
+      end
+
+      def self.credentials
+        Paperclip::Attachment.default_options[:azure_credentials]
+      end
+    end
+  end
+end


### PR DESCRIPTION
Azure is now offering their services also from German data centers which is a separate setup from azures global offer. They are using different urls to interact with the blob storage. Therefore, these urls need to be configurable. 