### PR TITLE
Updates to work with latest versions of Azure/azure-storage-ruby and thotbot/paperclip

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,12 +4,14 @@
 ### Ruby ###
 *.gem
 *.rbc
+*.swp
 /.config
 /coverage/
 /InstalledFiles
 /pkg/
 /spec/reports/
 /spec/examples.txt
+/spec/debug.log
 /test/tmp/
 /test/version_tmp/
 /tmp/

--- a/lib/paperclip-azure.rb
+++ b/lib/paperclip-azure.rb
@@ -2,12 +2,15 @@ require 'azure'
 
 require File.join(File.dirname(__FILE__), 'paperclip', 'storage', 'azure')
 
-module Azure
+module Azure::Storage
   module Blob
     BlobService.class_eval do
-      def initialize(signer=Core::Auth::SharedKey.new, account_name=Azure.config.storage_account_name)
-        super(signer, account_name)
-        @host = Paperclip::Storage::AzureRegion.url_for account_name
+      original_initialize = instance_method(:initialize)
+
+      define_method(:initialize) do |options, &block|
+        original_initialize.bind(self).(options, &block)
+        account_name = options[:client].storage_account_name
+        @host = "https://#{Paperclip::Storage::Azure::Environment.url_for(account_name)}"
       end
     end
   end

--- a/lib/paperclip/storage/azure.rb
+++ b/lib/paperclip/storage/azure.rb
@@ -192,7 +192,6 @@ module Paperclip
 
       def flush_writes #:nodoc:
         @queued_for_write.each do |style, file|
-          retries = 0
           begin
             log("saving #{path(style)}")
 
@@ -221,7 +220,6 @@ module Paperclip
       end
 
       def save_blob(container_name, storage_path, file, write_options)
-
         if file.size < 64.megabytes
           azure_interface.create_block_blob container_name, storage_path, file.read, write_options
         else
@@ -229,7 +227,7 @@ module Paperclip
           while data = file.read(4.megabytes)
             block_id = "block_#{(count += 1).to_s.rjust(5, '0')}"
 
-            azure_interface.create_blob_block container_name, storage_path, block_id, data
+            azure_interface.put_blob_block container_name, storage_path, block_id, data
 
             blocks << [block_id]
           end
@@ -254,7 +252,7 @@ module Paperclip
       def copy_to_local_file(style, local_dest_path)
         log("copying #{path(style)} to local file #{local_dest_path}")
 
-        blob, content = azure_interface.get_blob(container_name, path(style).sub(%r{\A/},''))
+        _, content = azure_interface.get_blob(container_name, path(style).sub(%r{\A/},''))
 
         ::File.open(local_dest_path, 'wb') do |local_file|
           local_file.write(content)


### PR DESCRIPTION
azure-storage-ruby has a breaking change: `#create_blob_block` was renamed to `#put_blob_block`.

https://github.com/Azure/azure-storage-ruby/blob/master/BreakingChanges.md

Also it looks like paperclip has changed `Paperclip::Storage::AzureRegion` to  `Paperclip::Storage::Azure::Environment`.

The changes in this PR got my app back working again.