### PR TITLE
Pass argument to azure_uri in expiring_url

### DIFF
--- a/lib/paperclip/storage/azure.rb
+++ b/lib/paperclip/storage/azure.rb
@@ -89,7 +89,7 @@ module Paperclip
             azure_credentials[:storage_access_key]
           )
           obj_path = path(style_name).gsub(%r{\A/}, '')
-          "#{azure_uri}?#{signer.generate_token(container_name, obj_path, 'r', time)}"
+          "#{azure_uri(style_name)}?#{signer.generate_token(container_name, obj_path, 'r', time)}"
         else
           url(style_name)
         end


### PR DESCRIPTION
Fixing the issue where the style_name specified during the expiring_url method call is not being passed to the azure_uri method.